### PR TITLE
Remove newline from end of code-block regex

### DIFF
--- a/plugin/hackernews.py
+++ b/plugin/hackernews.py
@@ -256,7 +256,7 @@ def print_comments(comments):
             # Extract code block before textwrap to conserve whitespace
             code = None
             if p.find("<code>") >= 0:
-                m = re.search("<pre><code>([\S\s]*?)</code></pre>\n", p)
+                m = re.search("<pre><code>([\S\s]*?)</code></pre>", p)
                 code = m.group(1)
                 p = p.replace(m.group(0), "!CODE!")
 


### PR DESCRIPTION
The current regex assumes that `</pre>` is always followed by a newline. That isn't always the case, e.g. [this comment](https://news.ycombinator.com/item?id=9020300), or [this one](https://news.ycombinator.com/item?id=9018878), so you get a stacktrace when opening e.g. the "Modern SQL in PostgreSQL" thread:
```
".hackernews" [New File]
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/Users/simon/.janus/vim-hackernews/plugin/hackernews.py", line 132, in hacker_news_link
    print_comments(item['comments'])
  File "/Users/simon/.janus/vim-hackernews/plugin/hackernews.py", line 295, in print_comments
    print_comments(comment['comments'])
  File "/Users/simon/.janus/vim-hackernews/plugin/hackernews.py", line 260, in print_comments
    code = m.group(1)
AttributeError: 'NoneType' object has no attribute 'group'
```