### PR TITLE
Fix HTTPError message

### DIFF
--- a/ftplugin/hackernews.py
+++ b/ftplugin/hackernews.py
@@ -80,7 +80,7 @@ def main():
         news2 = json.loads(urlopen(API_URL+"/news2", timeout=5)
                            .read().decode('utf-8'))
     except HTTPError:
-        print("HackerNews.vim Error: %s" % str(sys.exc_info()[1][0]))
+        print("HackerNews.vim Error: %s" % str(sys.exc_info()[1].reason))
         return
     except:
         print("HackerNews.vim Error: HTTP Request Timeout")


### PR DESCRIPTION
On my setup (vim7.4 with python2.7) I'm getting next error:
```
Traceback (most recent call last):
  File "<string>", line 1, in <module>
    File "/home/wtf/.vim/bundle/vim-hackernews/ftplugin/hackernews.py", line 83, in main
        print("HackerNews.vim Error: %s" % str(sys.exc_info()[1][0]))
        IndexError: tuple index out of range
```

From python `HTTPError` docs:
```
Otherwise, the values returned are (type, value, traceback).
Their meaning is: type gets the type of the exception being handled (a subclass of BaseException);
value gets the exception instance (an instance of the exception type);
```
Therefore `value` is an instance of HTTPError and reasonable method too obtain error string is `value.reason`
