### PR TITLE
Syntax highlighting in initial HackerNews buffer

### DIFF
--- a/ftplugin/hackernews.py
+++ b/ftplugin/hackernews.py
@@ -120,6 +120,7 @@ def main():
             bwrite(line)
         bwrite("")
     vim.command("setlocal undolevels=100")
+    vim.command("set syntax=hackernews")
 
 
 def link(external=False):


### PR DESCRIPTION
Upon calling the HackerNews function, the newly created buffer would not have syntax highlighting. Syntax highlighting would only be activated on viewing an article, and then returning to the main view, via the `recall_pos` function. This fix executes `set syntax=hackernews` after creating the initial buffer.